### PR TITLE
Switch "open in web" icon

### DIFF
--- a/PReek/Views/PullRequestViews/EventView.swift
+++ b/PReek/Views/PullRequestViews/EventView.swift
@@ -56,7 +56,7 @@ struct EventView: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 130, alignment: .trailing)
                 HoverableLink(destination: event.url) {
-                    Image(systemName: "safari")
+                    Image(systemName: "arrow.up.forward.square")
                 }
             }
             EventDataView(event.data)

--- a/PReek/Views/PullRequestViews/EventView.swift
+++ b/PReek/Views/PullRequestViews/EventView.swift
@@ -56,7 +56,7 @@ struct EventView: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 130, alignment: .trailing)
                 HoverableLink(destination: event.url) {
-                    Image(systemName: "square.and.arrow.up")
+                    Image(systemName: "safari")
                 }
             }
             EventDataView(event.data)


### PR DESCRIPTION
This now uses the `safari` icon instead of the `square.and.arrow.up` symbol. The latter usually signifies some sort of sharing, while the safari symbol is ubiquitous for the web in macOS